### PR TITLE
chore: remove dark mode toggle and theming from tic-tac-toe.html (issue #15)

### DIFF
--- a/tic-tac-toe.html
+++ b/tic-tac-toe.html
@@ -14,25 +14,9 @@
       --win-bg: rgba(28,197,138,0.12);
       color-scheme: dark;
 
-      /* Mark sizing variables (responsive):
-         --mark-min: minimum size (rem)
-         --mark-vw-factor: responsive factor (based on viewport)
-         --mark-max: maximum size (rem)
-      */
       --mark-min: 2rem;
       --mark-vw-factor: 10vw;
       --mark-max: 7rem;
-    }
-
-    /* Light theme overrides: applied when html[data-theme="light"] is set */
-    html[data-theme="light"] {
-      --bg: #e6eef8; /* slightly darker light background to reduce glare */
-      --accent: #7c3aed; /* retain accent */
-      --x: #b91c1c; /* darker red for contrast */
-      --o: #0ea5a4; /* teal */
-      --muted: #334155; /* darker slate for improved readability */
-      --win-bg: rgba(16,185,129,0.12); /* slightly stronger win highlight */
-      color-scheme: light;
     }
 
     * {
@@ -48,11 +32,7 @@
       margin: 0;
       font-family: system-ui, -apple-system,
         "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-      background: linear-gradient(
-        180deg,
-        var(--bg),
-        #071021 120%
-      );
+      background: linear-gradient(180deg, var(--bg), #071021 120%);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -61,39 +41,16 @@
       transition: background 220ms ease, color 220ms ease;
     }
 
-    /* When in light theme make some text colors darker for contrast */
-    html[data-theme="light"] body {
-      color: #0f1724;
-      background: linear-gradient(
-        180deg,
-        var(--bg),
-        #e6eef8 120%
-      );
-    }
-
     .ttt__container {
       width: 100%;
       max-width: 720px;
-      background: linear-gradient(
-        180deg,
-        rgba(255,255,255,0.02),
-        rgba(255,255,255,0.01)
-      );
+      background: linear-gradient(180deg, rgba(255,255,255,0.02),
+                   rgba(255,255,255,0.01));
       border-radius: 12px;
       padding: 20px 20px 28px;
       box-shadow: 0 6px 30px rgba(2,6,23,0.6);
       transition: background 220ms ease, color 220ms ease,
         box-shadow 220ms ease;
-    }
-
-    /* Slightly different container treatment for light theme */
-    html[data-theme="light"] .ttt__container {
-      background: linear-gradient(
-        180deg,
-        rgba(2,6,23,0.04),
-        rgba(2,6,23,0.02)
-      );
-      box-shadow: 0 8px 26px rgba(2,6,23,0.08);
     }
 
     header {
@@ -148,34 +105,14 @@
       cursor: pointer;
       transition: transform 0.08s ease, background 0.12s,
         border-color 180ms ease, color 180ms ease;
-      user-select: none; /* prevent text selection on mark */
+      user-select: none;
     }
 
-    /* When in light theme adjust borders so they are visible */
-    html[data-theme="light"] .ttt__cell {
-      border: 1px solid rgba(2,6,23,0.12);
-      background: linear-gradient(180deg, rgba(2,6,23,0.04), rgba(2,6,23,0.02));
-    }
-
-    /* If SVG marks are added later, make them scale nicely inside the cell */
-    .ttt__cell svg {
-      width: 75%;
-      height: 75%;
-      display: block;
-    }
-
-    .ttt__cell svg .stroke {
-      stroke-linecap: round;
-      stroke-linejoin: round;
-    }
+    .ttt__cell:hover { transform: translateY(-3px); }
 
     .ttt__cell:focus {
       outline: 3px solid rgba(124,58,237,0.18);
       transform: scale(1.02);
-    }
-
-    .ttt__cell:hover {
-      transform: translateY(-3px);
     }
 
     .ttt__cell--x {
@@ -209,11 +146,6 @@
         color 160ms ease;
     }
 
-    /* Stronger button borders in light theme for visibility */
-    html[data-theme="light"] .ttt__btn {
-      border-color: rgba(2,6,23,0.12);
-    }
-
     .ttt__btn--primary {
       background: linear-gradient(90deg, var(--accent), #4f46e5);
       border: none;
@@ -237,17 +169,7 @@
       border-radius: 8px;
     }
 
-    /* Theme toggle wrapper moved to CSS (no inline styles) */
-    .ttt__theme-toggle {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      margin-left: 12px;
-    }
-
     @media (max-width: 420px) {
-      /* On small screens let the clamp handle sizing, but slightly reduce
-         max viewport factor */
       :root {
         --mark-vw-factor: 18vw;
       }
@@ -263,18 +185,6 @@
     <header>
       <h1>Tic Tac Toe</h1>
 
-      <!-- Theme toggle button: accessible, keyboard focusable. -->
-      <div class="ttt__theme-toggle">
-        <button
-          id="themeToggle"
-          class="ttt__btn ttt__theme-toggle__btn"
-          aria-label="Toggle light/dark theme"
-          title="Toggle light/dark theme"
-        >
-          🌙
-        </button>
-      </div>
-
       <div class="ttt__status">
         <div id="statusMsg" class="ttt__status-msg" aria-live="polite">
           Player X's turn
@@ -285,73 +195,18 @@
       </div>
     </header>
 
-    <section
-      class="ttt__board"
-      role="grid"
-      aria-label="Tic Tac Toe board"
-    >
-      <button
-        class="ttt__cell"
-        data-index="0"
-        aria-label="Row 1, Column 1, empty"
-        aria-pressed="false"
-      ></button>
+    <section class="ttt__board" role="grid" aria-label="Tic Tac Toe board">
+      <button class="ttt__cell" data-index="0" aria-label="Row 1, Column 1, empty" aria-pressed="false"></button>
+      <button class="ttt__cell" data-index="1" aria-label="Row 1, Column 2, empty" aria-pressed="false"></button>
+      <button class="ttt__cell" data-index="2" aria-label="Row 1, Column 3, empty" aria-pressed="false"></button>
 
-      <button
-        class="ttt__cell"
-        data-index="1"
-        aria-label="Row 1, Column 2, empty"
-        aria-pressed="false"
-      ></button>
+      <button class="ttt__cell" data-index="3" aria-label="Row 2, Column 1, empty" aria-pressed="false"></button>
+      <button class="ttt__cell" data-index="4" aria-label="Row 2, Column 2, empty" aria-pressed="false"></button>
+      <button class="ttt__cell" data-index="5" aria-label="Row 2, Column 3, empty" aria-pressed="false"></button>
 
-      <button
-        class="ttt__cell"
-        data-index="2"
-        aria-label="Row 1, Column 3, empty"
-        aria-pressed="false"
-      ></button>
-
-      <button
-        class="ttt__cell"
-        data-index="3"
-        aria-label="Row 2, Column 1, empty"
-        aria-pressed="false"
-      ></button>
-
-      <button
-        class="ttt__cell"
-        data-index="4"
-        aria-label="Row 2, Column 2, empty"
-        aria-pressed="false"
-      ></button>
-
-      <button
-        class="ttt__cell"
-        data-index="5"
-        aria-label="Row 2, Column 3, empty"
-        aria-pressed="false"
-      ></button>
-
-      <button
-        class="ttt__cell"
-        data-index="6"
-        aria-label="Row 3, Column 1, empty"
-        aria-pressed="false"
-      ></button>
-
-      <button
-        class="ttt__cell"
-        data-index="7"
-        aria-label="Row 3, Column 2, empty"
-        aria-pressed="false"
-      ></button>
-
-      <button
-        class="ttt__cell"
-        data-index="8"
-        aria-label="Row 3, Column 3, empty"
-        aria-pressed="false"
-      ></button>
+      <button class="ttt__cell" data-index="6" aria-label="Row 3, Column 1, empty" aria-pressed="false"></button>
+      <button class="ttt__cell" data-index="7" aria-label="Row 3, Column 2, empty" aria-pressed="false"></button>
+      <button class="ttt__cell" data-index="8" aria-label="Row 3, Column 3, empty" aria-pressed="false"></button>
     </section>
 
     <div class="ttt__controls">
@@ -382,9 +237,6 @@
       const scoreXEl = document.getElementById('scoreX');
       const scoreOEl = document.getElementById('scoreO');
       const scoreDEl = document.getElementById('scoreD');
-      const themeToggleBtn = document.getElementById('themeToggle');
-
-      const THEME_KEY = 'ttt-theme';
 
       const WINNING_COMBOS = [
         [0, 1, 2],
@@ -402,76 +254,8 @@
       let isGameActive = true;
       const SCORE = { X: 0, O: 0, draws: 0 };
 
-      /* Theme management */
-      function applyTheme(theme) {
-        if (theme === 'light') {
-          document.documentElement.setAttribute('data-theme', 'light');
-          themeToggleBtn.textContent = '☀️';
-          themeToggleBtn.setAttribute('aria-pressed', 'true');
-          themeToggleBtn.setAttribute('aria-label', 'Switch to dark theme');
-          try { localStorage.setItem(THEME_KEY, 'light'); } catch (e) {}
-        } else {
-          document.documentElement.removeAttribute('data-theme');
-          themeToggleBtn.textContent = '🌙';
-          themeToggleBtn.setAttribute('aria-pressed', 'false');
-          themeToggleBtn.setAttribute('aria-label', 'Switch to light theme');
-          try { localStorage.setItem(THEME_KEY, 'dark'); } catch (e) {}
-        }
-
-        // Also set the color-scheme property directly for some browsers
-        try {
-          document.documentElement.style.colorScheme = theme === 'light' ? 'light' : 'dark';
-        } catch (e) {}
-      }
-
-      function getSavedTheme() {
-        try { return localStorage.getItem(THEME_KEY); } catch (e) { return null; }
-      }
-
-      function getPreferredThemeFromSystem() {
-        try {
-          if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
-            return 'light';
-          }
-        } catch (e) {}
-
-        return 'dark';
-      }
-
-      function toggleTheme() {
-        const current = (document.documentElement.getAttribute('data-theme') === 'light')
-          ? 'light' : 'dark';
-        const next = (current === 'light') ? 'dark' : 'light';
-        applyTheme(next);
-      }
-
-      function initTheme() {
-        const saved = getSavedTheme();
-        const initial = saved || getPreferredThemeFromSystem();
-        applyTheme(initial);
-
-        // If the user didn't choose explicitly, respond to OS changes.
-        try {
-          const mq = window.matchMedia('(prefers-color-scheme: dark)');
-          const mqHandler = (e) => {
-            if (!getSavedTheme()) {
-              applyTheme(e.matches ? 'dark' : 'light');
-            }
-          };
-
-          if (mq.addEventListener) {
-            mq.addEventListener('change', mqHandler);
-          } else if (mq.addListener) {
-            mq.addListener(mqHandler);
-          }
-        } catch (e) {}
-
-        themeToggleBtn.addEventListener('click', toggleTheme);
-      }
-
       function init() {
-        initTheme();
-
+        // initialize board and controls
         cellEls.forEach(cell => {
           cell.addEventListener('click', onCellClick);
           cell.addEventListener('keydown', onCellKeyDown);
@@ -480,8 +264,7 @@
         newGameBtn.addEventListener('click', resetGame);
         resetScoresBtn.addEventListener('click', resetScores);
 
-        updateStatus('Player ' + currentPlayer + "'s turn");
-
+        updateStatus("Player " + currentPlayer + "'s turn");
         render();
       }
 
@@ -592,16 +375,17 @@
           cell.classList.remove('ttt__cell--o');
           cell.classList.remove('ttt__cell--win');
 
+          const r = Math.floor(i / 3) + 1;
+          const c = (i % 3) + 1;
           cell.setAttribute(
             'aria-label',
-            'Row ' + (Math.floor(i / 3) + 1) + ', Column ' + ((i % 3) + 1) + ', empty'
+            'Row ' + r + ', Column ' + c + ', empty'
           );
 
           cell.setAttribute('aria-pressed', 'false');
         });
 
-        updateStatus('Player ' + currentPlayer + "'s turn");
-
+        updateStatus("Player " + currentPlayer + "'s turn");
         cellEls[0].focus();
       }
 


### PR DESCRIPTION
Removed the dark mode toggle from the Tic Tac Toe app as requested in issue #15. Theming logic and UI have been removed from tic-tac-toe.html, leaving a single-file, fully client-side game that renders in dark mode by default with no theme switch. All game mechanics (board state, win/draw logic, scoring, New Game, Reset Scores) remain intact. The change does not introduce any new files. Branch feature/15-remove-theme created from main. How to test:
- Open tic-tac-toe.html
- Confirm there is no option to switch themes (no theme toggle UI)
- Play moves (X vs O), win/draw detection works, and scores update accordingly
- Use New Game to reset the board, and Reset Scores to clear the counters
- Reloading the page should reset scores (no localStorage persistence for scores)