### PR TITLE
Increase X/O mark sizes to better fill board cells (issue #8)

### DIFF
--- a/tic-tac-toe.html
+++ b/tic-tac-toe.html
@@ -14,9 +14,9 @@
       --win-bg: rgba(28,197,138,0.12);
       color-scheme: dark;
 
-      --mark-min: 2rem;
-      --mark-vw-factor: 10vw;
-      --mark-max: 7rem;
+      --mark-min: 2.8rem;
+      --mark-vw-factor: 12vw;
+      --mark-max: 9rem;
     }
 
     * {
@@ -248,7 +248,7 @@
 
     @media (max-width: 420px) {
       :root {
-        --mark-vw-factor: 18vw;
+        --mark-vw-factor: 20vw;
       }
 
       h1 {


### PR DESCRIPTION
Adjusts the responsive sizing of the X and O marks so they better match the size of each board square.

Changes:
- tic-tac-toe.html: increased CSS variables used by clamp() for cell font-size:
  - --mark-min: 2.8rem
  - --mark-vw-factor: 12vw
  - --mark-max: 9rem
  - mobile override --mark-vw-factor: 20vw

Summary Context:
The system being built is a Tic Tac Toe web application using only HTML, CSS, and JavaScript. The whole app runs in the browser without any backend. The app is contained within a single HTML file named tic-tac-toe.html. No new files were added.

No JS or markup changes were necessary — this is a focused visual tweak to better match the marks to the cells.