### PR TITLE
Add animated splash screen for game results (win/lose/draw)

### DIFF
--- a/tic-tac-toe.html
+++ b/tic-tac-toe.html
@@ -498,6 +498,7 @@
 
         // show overlay
         splashOverlay.setAttribute('aria-hidden', 'false');
++        splashCard.setAttribute('aria-hidden', 'false');
         splashOverlay.classList.add('splash__overlay--visible');
 
         // focus the overlay so screen reader users land on it
@@ -523,7 +524,9 @@
         }
 
         splashOverlay.classList.remove('splash__overlay--visible');
-        splashOverlay.setAttribute('aria-hidden', 'true');
+-        splashOverlay.setAttribute('aria-hidden', 'true');
++        splashOverlay.setAttribute('aria-hidden', 'true');
++        splashCard.setAttribute('aria-hidden', 'true');
 
         // small delay to allow opacity transition to finish before resetting game
         setTimeout(function () {


### PR DESCRIPTION
Adds a visually engaging splash overlay shown after each round finishes (win / lose / draw). The overlay displays a short animated card with variants for success, loss, and draw, blocks interactions for 2 seconds, announces the result via an accessible live region, and starts the next round automatically. All changes are contained in tic-tac-toe.html; the app remains a single-file Tic Tac Toe web app (HTML/CSS/JS) that runs entirely in the browser.