### PR TITLE
feat: add dark/light theme toggle with persistence (issue #10)

### DIFF
--- a/tic-tac-toe.html
+++ b/tic-tac-toe.html
@@ -5,12 +5,38 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Tic Tac Toe</title>
   <style>
+    /*
+      Theme variables
+      - Default (dark) lives in :root
+      - Light theme overrides live in html[data-theme="light"]
+    */
     :root {
       --bg: #0f1724;
+      --bg-2: #071021; /* secondary background stop */
+      --container-bg: rgba(255,255,255,0.02);
+      --cell-bg: linear-gradient(180deg, rgba(255,255,255,0.01), transparent);
+      --cell-border: rgba(255,255,255,0.04);
       --x: #e11d48;
       --o: #06b6d4;
       --muted: #94a3b8;
+      --text: #e6eef8;
+      --primary-grad: linear-gradient(90deg, #4f46e5, #7c3aed);
       color-scheme: dark;
+    }
+
+    /* Light theme overrides */
+    html[data-theme="light"] {
+      --bg: #f8fafc;
+      --bg-2: #eef2ff;
+      --container-bg: #ffffff;
+      --cell-bg: linear-gradient(180deg, rgba(2,6,23,0.02), transparent);
+      --cell-border: rgba(2,6,23,0.06);
+      --x: #b91c1c;
+      --o: #0ea5a4;
+      --muted: #475569;
+      --text: #0b1220;
+      --primary-grad: linear-gradient(90deg, #4338ca, #6d28d9);
+      color-scheme: light;
     }
 
     * {
@@ -21,23 +47,25 @@
     body {
       margin: 0;
       font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-      background: linear-gradient(180deg, var(--bg), #071021 120%);
+      background: linear-gradient(180deg, var(--bg), var(--bg-2) 120%);
       display: flex;
       align-items: center;
       justify-content: center;
       padding: 24px;
-      color: #e6eef8;
+      color: var(--text);
+      transition: background 240ms ease, color 240ms ease;
     }
 
     .ttt__container {
       width: 100%;
       max-width: 720px;
-      background: rgba(255,255,255,0.02);
+      background: var(--container-bg);
       border-radius: 12px;
       padding: 20px 20px 28px;
-      box-shadow: 0 6px 30px rgba(2,6,23,0.6);
+      box-shadow: 0 6px 30px rgba(2,6,23,0.06);
       position: relative;
       overflow: visible;
+      transition: background 200ms ease, box-shadow 200ms ease;
     }
 
     header {
@@ -48,6 +76,7 @@
       margin-bottom: 14px;
     }
 
+    .ttt__title-row { display: flex; gap: 12px; align-items: center; }
     h1 { font-size: 20px; margin: 0; }
 
     .ttt__status { display: flex; flex-direction: column; align-items: flex-end; }
@@ -65,8 +94,8 @@
       aspect-ratio: 1/1;
       padding: 0;
       border-radius: 10px;
-      border: 2px solid rgba(255,255,255,0.04);
-      background: linear-gradient(180deg, rgba(255,255,255,0.01), transparent);
+      border: 2px solid var(--cell-border);
+      background: var(--cell-bg);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -76,6 +105,7 @@
       color: var(--muted);
       cursor: pointer;
       user-select: none;
+      transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
     }
 
     .ttt__cell:focus { outline: 3px solid rgba(124,58,237,0.18); }
@@ -100,8 +130,11 @@
       transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
     }
 
+    /* Icon-style button variant */
+    .ttt__btn--icon { padding: 8px; height: 36px; min-width: 36px; display: inline-flex; align-items: center; justify-content: center; }
+
     .ttt__btn--primary {
-      background: linear-gradient(90deg, #4f46e5, #7c3aed);
+      background: var(--primary-grad);
       border: none;
       color: white;
     }
@@ -119,7 +152,12 @@
 <body>
   <main class="ttt__container">
     <header>
-      <h1>Tic Tac Toe</h1>
+      <div class="ttt__title-row">
+        <h1>Tic Tac Toe</h1>
+        <!-- Theme toggle button -->
+        <button id="themeToggle" class="ttt__btn ttt__btn--icon" title="Toggle theme" aria-pressed="false" aria-label="Toggle dark and light theme">🌙</button>
+      </div>
+
       <div class="ttt__status">
         <div id="statusMsg" class="ttt__status-msg" aria-live="polite">Waiting...</div>
         <div class="ttt__status-sub">Click a cell or use keyboard (Tab + Enter/Space)</div>
@@ -161,6 +199,9 @@
       const scoreXEl = document.getElementById('scoreX');
       const scoreOEl = document.getElementById('scoreO');
       const scoreDEl = document.getElementById('scoreD');
+      const themeToggleBtn = document.getElementById('themeToggle');
+
+      const THEME_KEY = 'ttt:theme';
 
       const WINNING_COMBOS = [
         [0,1,2], [3,4,5], [6,7,8],
@@ -183,6 +224,71 @@
       let isGameActive = true;
       const SCORE = { X: 0, O: 0, draws: 0 };
 
+      /* Theme helpers */
+      function getSavedTheme() {
+        try {
+          return localStorage.getItem(THEME_KEY);
+        } catch (e) {
+          return null;
+        }
+      }
+
+      function getSystemTheme() {
+        try {
+          if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) return 'light';
+        } catch (e) { /* ignore */ }
+        return 'dark';
+      }
+
+      function applyTheme(theme) {
+        if (!theme) return;
+        document.documentElement.dataset.theme = theme;
+        const isLight = theme === 'light';
+        if (themeToggleBtn) {
+          themeToggleBtn.textContent = isLight ? '☀️' : '🌙';
+          themeToggleBtn.setAttribute('aria-pressed', isLight ? 'true' : 'false');
+          themeToggleBtn.title = isLight ? 'Switch to dark theme' : 'Switch to light theme';
+          themeToggleBtn.setAttribute('aria-label', isLight ? 'Light theme active. Switch to dark.' : 'Dark theme active. Switch to light.');
+        }
+      }
+
+      function toggleTheme() {
+        const current = document.documentElement.dataset.theme || getSystemTheme();
+        const next = current === 'light' ? 'dark' : 'light';
+        try { localStorage.setItem(THEME_KEY, next); } catch (e) {}
+        applyTheme(next);
+      }
+
+      function initTheme() {
+        const saved = getSavedTheme();
+        const toApply = saved || getSystemTheme();
+        applyTheme(toApply);
+
+        if (themeToggleBtn) {
+          themeToggleBtn.addEventListener('click', toggleTheme);
+        }
+
+        // react to system preference changes when user has not manually chosen
+        try {
+          if (!saved && window.matchMedia) {
+            const mq = window.matchMedia('(prefers-color-scheme: light)');
+            if (mq.addEventListener) {
+              mq.addEventListener('change', (ev) => {
+                if (!getSavedTheme()) {
+                  applyTheme(ev.matches ? 'light' : 'dark');
+                }
+              });
+            } else if (mq.addListener) {
+              mq.addListener((ev) => {
+                if (!getSavedTheme()) {
+                  applyTheme(ev.matches ? 'light' : 'dark');
+                }
+              });
+            }
+          }
+        } catch (e) { /* ignore */ }
+      }
+
       function init() {
         cellEls.forEach(cell => {
           cell.addEventListener('click', onCellClick);
@@ -191,6 +297,8 @@
 
         newGameBtn.addEventListener('click', resetGame);
         resetScoresBtn.addEventListener('click', resetScores);
+
+        initTheme();
         updateStatus(`Player ${playerName(currentPlayer)}'s turn`);
         render();
       }

--- a/tic-tac-toe.html
+++ b/tic-tac-toe.html
@@ -16,6 +16,9 @@
       --container-bg: rgba(255,255,255,0.02);
       --cell-bg: linear-gradient(180deg, rgba(255,255,255,0.01), transparent);
       --cell-border: rgba(255,255,255,0.04);
+      --btn-border: rgba(255,255,255,0.06);
+      --score-bg: rgba(255,255,255,0.02);
+      --container-shadow: 0 6px 30px rgba(2,6,23,0.06);
       --x: #e11d48;
       --o: #06b6d4;
       --muted: #94a3b8;
@@ -31,6 +34,9 @@
       --container-bg: #ffffff;
       --cell-bg: linear-gradient(180deg, rgba(2,6,23,0.02), transparent);
       --cell-border: rgba(2,6,23,0.06);
+      --btn-border: rgba(2,6,23,0.06);
+      --score-bg: rgba(2,6,23,0.02);
+      --container-shadow: 0 6px 20px rgba(2,6,23,0.04);
       --x: #b91c1c;
       --o: #0ea5a4;
       --muted: #475569;
@@ -62,7 +68,7 @@
       background: var(--container-bg);
       border-radius: 12px;
       padding: 20px 20px 28px;
-      box-shadow: 0 6px 30px rgba(2,6,23,0.06);
+      box-shadow: var(--container-shadow);
       position: relative;
       overflow: visible;
       transition: background 200ms ease, box-shadow 200ms ease;
@@ -122,7 +128,7 @@
 
     .ttt__btn {
       background: transparent;
-      border: 1px solid rgba(255,255,255,0.06);
+      border: 1px solid var(--btn-border);
       color: inherit;
       padding: 8px 12px;
       border-radius: 8px;
@@ -140,10 +146,9 @@
     }
 
     .ttt__score { display: flex; gap: 12px; align-items: center; color: var(--muted); font-size: 14px; }
-    .ttt__score-item { display: inline-flex; gap: 6px; align-items: center; background: rgba(255,255,255,0.02); padding: 6px 8px; border-radius: 8px; }
+    .ttt__score-item { display: inline-flex; gap: 6px; align-items: center; background: var(--score-bg); padding: 6px 8px; border-radius: 8px; }
 
     @media (max-width: 420px) {
-      :root { --mark-vw-factor: 18vw; }
       .ttt__container { padding: 14px; }
     }
 
@@ -227,10 +232,12 @@
       /* Theme helpers */
       function getSavedTheme() {
         try {
-          return localStorage.getItem(THEME_KEY);
+          const v = localStorage.getItem(THEME_KEY);
+          if (v === 'light' || v === 'dark') return v;
         } catch (e) {
-          return null;
+          /* ignore */
         }
+        return null;
       }
 
       function getSystemTheme() {
@@ -240,10 +247,16 @@
         return 'dark';
       }
 
+      function normalizeTheme(t) {
+        return t === 'light' ? 'light' : 'dark';
+      }
+
       function applyTheme(theme) {
         if (!theme) return;
-        document.documentElement.dataset.theme = theme;
-        const isLight = theme === 'light';
+        // validate theme input
+        const valid = (theme === 'light' || theme === 'dark') ? theme : 'dark';
+        document.documentElement.dataset.theme = valid;
+        const isLight = valid === 'light';
         if (themeToggleBtn) {
           themeToggleBtn.textContent = isLight ? '☀️' : '🌙';
           themeToggleBtn.setAttribute('aria-pressed', isLight ? 'true' : 'false');
@@ -253,10 +266,12 @@
       }
 
       function toggleTheme() {
-        const current = document.documentElement.dataset.theme || getSystemTheme();
+        const rawCurrent = document.documentElement.dataset.theme || getSystemTheme();
+        const current = (rawCurrent === 'light' || rawCurrent === 'dark') ? rawCurrent : getSystemTheme();
         const next = current === 'light' ? 'dark' : 'light';
-        try { localStorage.setItem(THEME_KEY, next); } catch (e) {}
-        applyTheme(next);
+        const validated = normalizeTheme(next);
+        try { localStorage.setItem(THEME_KEY, validated); } catch (e) {}
+        applyTheme(validated);
       }
 
       function initTheme() {


### PR DESCRIPTION
Add dark and light mode that can be toggled by the user.

Changes:
- Added a theme toggle button in the header (id="themeToggle") with accessible attributes and icon.
- Introduced CSS custom properties and a light-theme override: html[data-theme="light"].
  - Theme variables control backgrounds, text, cell styles, borders, and primary button gradient.
  - color-scheme is set per theme for UA-native control styling.
- Replaced hard-coded colors with variables so the UI adapts between dark and light.
- JavaScript:
  - Added theme helpers to read/save persistently to localStorage (key: ttt:theme).
  - Detects system preference (prefers-color-scheme) on first load and reacts to changes when no user choice exists.
  - Applies theme immediately and updates the toggle's aria-pressed, title, and label.
  - Validates theme values before applying/storing.

Notes:
- Single-file change only: tic-tac-toe.html
- The system being built is a Tic Tac Toe web application using only HTML, CSS, and JavaScript. The whole app runs in the browser without any backend. The app is contained within a single HTML file named tic-tac-toe.html.

Closes #10.