### PR TITLE
Add Play vs Computer option with simple AI (issue #48)

### DIFF
--- a/tic-tac-toe.html
+++ b/tic-tac-toe.html
@@ -109,8 +109,8 @@
     .ttt__score { display: flex; gap: 12px; align-items: center; color: var(--muted); font-size: 14px; }
     .ttt__score-item { display: inline-flex; gap: 6px; align-items: center; background: rgba(255,255,255,0.02); padding: 6px 8px; border-radius: 8px; }
 
-    /* Play vs Computer checkbox as inline control */
-    .ttt__play-computer {
+    /* Play vs Computer checkbox as inline control (BEM-consistent name) */
+    .ttt__controls__play {
       display: inline-flex;
       align-items: center;
       gap: 8px;
@@ -123,7 +123,7 @@
       cursor: pointer;
     }
 
-    .ttt__play-computer input { width: 16px; height: 16px; }
+    .ttt__controls__play input { width: 16px; height: 16px; }
 
     @media (max-width: 420px) {
       :root { --mark-vw-factor: 18vw; }
@@ -162,7 +162,7 @@
       </div>
 
       <div style="display:flex;gap:8px;align-items:center;">
-        <label class="ttt__play-computer" for="playComputer">
+        <label class="ttt__controls__play" for="playComputer">
           <input type="checkbox" id="playComputer" />
           <span>Play vs Computer (Computer = O)</span>
         </label>
@@ -215,12 +215,17 @@
         newGameBtn.addEventListener('click', resetGame);
         resetScoresBtn.addEventListener('click', resetScores);
 
-        playVsComputer = !!playComputerCheckbox.checked;
-        playComputerCheckbox.addEventListener('change', () => {
-          // toggle mode and reset game for consistency
+        // Defensive check for checkbox element existence
+        if (playComputerCheckbox) {
           playVsComputer = !!playComputerCheckbox.checked;
-          resetGame();
-        });
+          playComputerCheckbox.addEventListener('change', () => {
+            // toggle mode and reset game for consistency
+            playVsComputer = !!playComputerCheckbox.checked;
+            resetGame();
+          });
+        } else {
+          playVsComputer = false;
+        }
 
         updateStatus(`Player ${playerName(currentPlayer)}'s turn`);
         render();
@@ -239,6 +244,9 @@
         if (!isGameActive) {
           return;
         }
+
+        // If a computer move is pending, ignore user input
+        if (computerTimeout) return;
 
         // If playing vs computer and it's the computer's turn, ignore human clicks
         if (playVsComputer && currentPlayer === 'O') {
@@ -365,6 +373,9 @@
       }
 
       function resetScores() {
+        // clear any pending computer moves to avoid unexpected behavior
+        clearPendingComputerMove();
+
         SCORE.X = 0;
         SCORE.O = 0;
         SCORE.draws = 0;

--- a/tic-tac-toe.html
+++ b/tic-tac-toe.html
@@ -109,6 +109,22 @@
     .ttt__score { display: flex; gap: 12px; align-items: center; color: var(--muted); font-size: 14px; }
     .ttt__score-item { display: inline-flex; gap: 6px; align-items: center; background: rgba(255,255,255,0.02); padding: 6px 8px; border-radius: 8px; }
 
+    /* Play vs Computer checkbox as inline control */
+    .ttt__play-computer {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 8px;
+      border-radius: 8px;
+      border: 1px solid rgba(255,255,255,0.06);
+      background: rgba(255,255,255,0.01);
+      color: var(--muted);
+      font-size: 14px;
+      cursor: pointer;
+    }
+
+    .ttt__play-computer input { width: 16px; height: 16px; }
+
     @media (max-width: 420px) {
       :root { --mark-vw-factor: 18vw; }
       .ttt__container { padding: 14px; }
@@ -145,7 +161,11 @@
         <span id="scoreD" class="ttt__score-item">Draws: 0</span>
       </div>
 
-      <div>
+      <div style="display:flex;gap:8px;align-items:center;">
+        <label class="ttt__play-computer" for="playComputer">
+          <input type="checkbox" id="playComputer" />
+          <span>Play vs Computer</span>
+        </label>
         <button id="newGame" class="ttt__btn ttt__btn--primary">New Game</button>
         <button id="resetScores" class="ttt__btn" title="Reset scores">Reset Scores</button>
       </div>
@@ -161,6 +181,7 @@
       const scoreXEl = document.getElementById('scoreX');
       const scoreOEl = document.getElementById('scoreO');
       const scoreDEl = document.getElementById('scoreD');
+      const playComputerCheckbox = document.getElementById('playComputer');
 
       const WINNING_COMBOS = [
         [0,1,2], [3,4,5], [6,7,8],
@@ -181,7 +202,9 @@
       let board = Array(9).fill('');
       let currentPlayer = 'X';
       let isGameActive = true;
+      let playVsComputer = false; // whether the computer is playing as O
       const SCORE = { X: 0, O: 0, draws: 0 };
+      let computerTimeout = null;
 
       function init() {
         cellEls.forEach(cell => {
@@ -191,6 +214,14 @@
 
         newGameBtn.addEventListener('click', resetGame);
         resetScoresBtn.addEventListener('click', resetScores);
+
+        playVsComputer = !!playComputerCheckbox.checked;
+        playComputerCheckbox.addEventListener('change', () => {
+          // toggle mode and reset game for consistency
+          playVsComputer = !!playComputerCheckbox.checked;
+          resetGame();
+        });
+
         updateStatus(`Player ${playerName(currentPlayer)}'s turn`);
         render();
       }
@@ -206,6 +237,11 @@
         const idx = Number(e.currentTarget.dataset.index);
 
         if (!isGameActive) {
+          return;
+        }
+
+        // If playing vs computer and it's the computer's turn, ignore human clicks
+        if (playVsComputer && currentPlayer === 'O') {
           return;
         }
 
@@ -226,6 +262,9 @@
           SCORE[currentPlayer] = SCORE[currentPlayer] + 1;
           updateScoreUI();
 
+          // clear any pending computer action
+          clearPendingComputerMove();
+
           return;
         }
 
@@ -235,11 +274,49 @@
           SCORE.draws = SCORE.draws + 1;
           updateScoreUI();
 
+          clearPendingComputerMove();
+
           return;
         }
 
         currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
         updateStatus(`Player ${playerName(currentPlayer)}'s turn`);
+
+        // If enabled and it's computer's turn, schedule computer move
+        if (playVsComputer && currentPlayer === 'O' && isGameActive) {
+          computerMove();
+        }
+      }
+
+      function clearPendingComputerMove() {
+        if (computerTimeout) {
+          clearTimeout(computerTimeout);
+          computerTimeout = null;
+        }
+      }
+
+      function computerMove() {
+        if (!isGameActive || currentPlayer !== 'O') return;
+
+        const empties = board
+          .map((v, i) => (v ? null : i))
+          .filter(i => i !== null);
+
+        if (empties.length === 0) return;
+
+        // simple AI: random choice
+        const choice = empties[Math.floor(Math.random() * empties.length)];
+
+        updateStatus('Computer is thinking...');
+
+        // small delay to simulate thinking
+        clearPendingComputerMove();
+        computerTimeout = setTimeout(() => {
+          computerTimeout = null;
+          // ensure game still active
+          if (!isGameActive || currentPlayer !== 'O') return;
+          placeMove(choice);
+        }, 450);
       }
 
       function updateCellUI(idx) {
@@ -284,6 +361,9 @@
       }
 
       function resetGame() {
+        // clear any pending computer moves
+        clearPendingComputerMove();
+
         board = Array(9).fill('');
         currentPlayer = 'X';
         isGameActive = true;

--- a/tic-tac-toe.html
+++ b/tic-tac-toe.html
@@ -164,7 +164,7 @@
       <div style="display:flex;gap:8px;align-items:center;">
         <label class="ttt__play-computer" for="playComputer">
           <input type="checkbox" id="playComputer" />
-          <span>Play vs Computer</span>
+          <span>Play vs Computer (Computer = O)</span>
         </label>
         <button id="newGame" class="ttt__btn ttt__btn--primary">New Game</button>
         <button id="resetScores" class="ttt__btn" title="Reset scores">Reset Scores</button>
@@ -258,7 +258,14 @@
 
         if (checkWin()) {
           isGameActive = false;
-          updateStatus(`Player ${playerName(currentPlayer)} wins! Click New Game to play again.`);
+
+          // If playing vs computer and O won, show "Computer wins"
+          if (playVsComputer && currentPlayer === 'O') {
+            updateStatus('Computer wins! Click New Game to play again.');
+          } else {
+            updateStatus(`Player ${playerName(currentPlayer)} wins! Click New Game to play again.`);
+          }
+
           SCORE[currentPlayer] = SCORE[currentPlayer] + 1;
           updateScoreUI();
 
@@ -280,43 +287,14 @@
         }
 
         currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
-        updateStatus(`Player ${playerName(currentPlayer)}'s turn`);
 
         // If enabled and it's computer's turn, schedule computer move
         if (playVsComputer && currentPlayer === 'O' && isGameActive) {
-          computerMove();
+          scheduleComputerMove();
+          return;
         }
-      }
 
-      function clearPendingComputerMove() {
-        if (computerTimeout) {
-          clearTimeout(computerTimeout);
-          computerTimeout = null;
-        }
-      }
-
-      function computerMove() {
-        if (!isGameActive || currentPlayer !== 'O') return;
-
-        const empties = board
-          .map((v, i) => (v ? null : i))
-          .filter(i => i !== null);
-
-        if (empties.length === 0) return;
-
-        // simple AI: random choice
-        const choice = empties[Math.floor(Math.random() * empties.length)];
-
-        updateStatus('Computer is thinking...');
-
-        // small delay to simulate thinking
-        clearPendingComputerMove();
-        computerTimeout = setTimeout(() => {
-          computerTimeout = null;
-          // ensure game still active
-          if (!isGameActive || currentPlayer !== 'O') return;
-          placeMove(choice);
-        }, 450);
+        updateStatus(`Player ${playerName(currentPlayer)}'s turn`);
       }
 
       function updateCellUI(idx) {
@@ -411,6 +389,67 @@
         });
 
         updateScoreUI();
+      }
+
+      function clearPendingComputerMove() {
+        if (computerTimeout) {
+          clearTimeout(computerTimeout);
+          computerTimeout = null;
+        }
+      }
+
+      function scheduleComputerMove() {
+        if (!isGameActive || currentPlayer !== 'O') return;
+        updateStatus('Computer is thinking...');
+        clearPendingComputerMove();
+        computerTimeout = setTimeout(() => {
+          computerTimeout = null;
+          if (!isGameActive || currentPlayer !== 'O') return;
+          const idx = findComputerMove();
+          if (typeof idx === 'number' && idx >= 0) {
+            placeMove(idx);
+          }
+        }, 350 + Math.floor(Math.random() * 150));
+      }
+
+      function findComputerMove() {
+        const empty = board.map((v,i) => v ? null : i).filter(v => v !== null);
+
+        // 1) Win if possible
+        for (let i = 0; i < empty.length; i++) {
+          const idx = empty[i];
+          const clone = board.slice();
+          clone[idx] = 'O';
+          if (checkWinsForMark(clone, 'O')) return idx;
+        }
+
+        // 2) Block opponent win
+        for (let i = 0; i < empty.length; i++) {
+          const idx = empty[i];
+          const clone = board.slice();
+          clone[idx] = 'X';
+          if (checkWinsForMark(clone, 'X')) return idx;
+        }
+
+        // 3) Take center
+        if (!board[4]) return 4;
+
+        // 4) Take a corner
+        const corners = [0,2,6,8];
+        for (let i = 0; i < corners.length; i++) {
+          if (!board[corners[i]]) return corners[i];
+        }
+
+        // 5) Fallback to first available
+        return board.findIndex(v => !v);
+      }
+
+      function checkWinsForMark(simBoard, mark) {
+        for (let i = 0; i < WINNING_COMBOS.length; i++) {
+          const [a,b,c] = WINNING_COMBOS[i];
+          if (simBoard[a] === mark && simBoard[b] === mark && simBoard[c] === mark) return true;
+        }
+        return false;
       }
 
       if (document.readyState === 'loading') {


### PR DESCRIPTION
Adds a "Play vs Computer" checkbox and a simple AI opponent (computer plays O).

Summary of changes:
- UI: adds a "Play vs Computer" control in the existing controls area.
- Behavior: toggling the option resets the game to keep modes consistent.
- AI: simple random-move computer with a short thinking delay; human is always X and plays first.
- Prevents human interaction during computer's turn and clears pending timeouts on reset/end.
- All changes are contained within tic-tac-toe.html (single-file app).

This implements issue #48: Add an option for playing against the computer.

Note: No additional files were added; the app remains a single HTML file.