### PR TITLE
Add dark/light theme toggle (issue #46)

### DIFF
--- a/tic-tac-toe.html
+++ b/tic-tac-toe.html
@@ -9,10 +9,10 @@
   <script>
     (function () {
       try {
-        var k = 'ttt_theme';
-        var s = localStorage.getItem(k);
-        if (s === 'light' || s === 'dark') {
-          document.documentElement.setAttribute('data-theme', s);
+        const THEME_KEY = 'ttt_theme';
+        const stored = localStorage.getItem(THEME_KEY);
+        if (stored === 'light' || stored === 'dark') {
+          document.documentElement.setAttribute('data-theme', stored);
         } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
           document.documentElement.setAttribute('data-theme', 'light');
         }

--- a/tic-tac-toe.html
+++ b/tic-tac-toe.html
@@ -10,7 +10,18 @@
       --x: #e11d48;
       --o: #06b6d4;
       --muted: #94a3b8;
+      --text: #e6eef8;
       color-scheme: dark;
+    }
+
+    /* Light theme overrides applied when document.documentElement has data-theme="light" */
+    :root[data-theme="light"] {
+      --bg: #f8fafc; /* slate-50 */
+      --x: #dc2626; /* red-600 */
+      --o: #0ea5a4; /* teal-ish */
+      --muted: #475569; /* slate-600 */
+      --text: #0f1724; /* slate-900 */
+      color-scheme: light;
     }
 
     * {
@@ -26,7 +37,7 @@
       align-items: center;
       justify-content: center;
       padding: 24px;
-      color: #e6eef8;
+      color: var(--text);
     }
 
     .ttt__container {
@@ -38,6 +49,13 @@
       box-shadow: 0 6px 30px rgba(2,6,23,0.6);
       position: relative;
       overflow: visible;
+    }
+
+    /* Adjust container background/borders for light theme */
+    :root[data-theme="light"] .ttt__container {
+      background: rgba(15,23,36,0.03);
+      box-shadow: 0 6px 18px rgba(2,6,23,0.06);
+      border: 1px solid rgba(2,6,23,0.04);
     }
 
     header {
@@ -78,6 +96,12 @@
       user-select: none;
     }
 
+    /* Lighter borders in light theme */
+    :root[data-theme="light"] .ttt__cell {
+      border-color: rgba(2,6,23,0.06);
+      background: linear-gradient(180deg, rgba(2,6,23,0.015), transparent);
+    }
+
     .ttt__cell:focus { outline: 3px solid rgba(124,58,237,0.18); }
 
     .ttt__cell--x { color: var(--x); }
@@ -100,6 +124,11 @@
       transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
     }
 
+    /* Button borders for light theme */
+    :root[data-theme="light"] .ttt__btn {
+      border-color: rgba(2,6,23,0.06);
+    }
+
     .ttt__btn--primary {
       background: linear-gradient(90deg, #4f46e5, #7c3aed);
       border: none;
@@ -120,9 +149,12 @@
   <main class="ttt__container">
     <header>
       <h1>Tic Tac Toe</h1>
-      <div class="ttt__status">
-        <div id="statusMsg" class="ttt__status-msg" aria-live="polite">Waiting...</div>
-        <div class="ttt__status-sub">Click a cell or use keyboard (Tab + Enter/Space)</div>
+      <div style="display:flex;align-items:center;gap:12px;">
+        <button id="themeToggle" class="ttt__btn" aria-pressed="false" aria-label="Toggle theme">🌙</button>
+        <div class="ttt__status">
+          <div id="statusMsg" class="ttt__status-msg" aria-live="polite">Waiting...</div>
+          <div class="ttt__status-sub">Click a cell or use keyboard (Tab + Enter/Space)</div>
+        </div>
       </div>
     </header>
 
@@ -161,6 +193,9 @@
       const scoreXEl = document.getElementById('scoreX');
       const scoreOEl = document.getElementById('scoreO');
       const scoreDEl = document.getElementById('scoreD');
+      const themeToggle = document.getElementById('themeToggle');
+
+      const THEME_KEY = 'ttt_theme';
 
       const WINNING_COMBOS = [
         [0,1,2], [3,4,5], [6,7,8],
@@ -183,6 +218,38 @@
       let isGameActive = true;
       const SCORE = { X: 0, O: 0, draws: 0 };
 
+      function applyTheme(theme) {
+        const t = theme === 'light' ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme', t);
+        // update toggle UI
+        if (themeToggle) {
+          const isLight = t === 'light';
+          themeToggle.setAttribute('aria-pressed', String(isLight));
+          themeToggle.setAttribute('aria-label', isLight ? 'Switch to dark theme' : 'Switch to light theme');
+          themeToggle.textContent = isLight ? '☀️' : '🌙';
+        }
+      }
+
+      function toggleTheme() {
+        const current = document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'dark';
+        const next = current === 'light' ? 'dark' : 'light';
+        try { localStorage.setItem(THEME_KEY, next); } catch (e) { /* ignore */ }
+        applyTheme(next);
+      }
+
+      function detectPreferredTheme() {
+        try {
+          const stored = localStorage.getItem(THEME_KEY);
+          if (stored === 'light' || stored === 'dark') return stored;
+        } catch (e) { /* ignore */ }
+
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
+          return 'light';
+        }
+
+        return 'dark';
+      }
+
       function init() {
         cellEls.forEach(cell => {
           cell.addEventListener('click', onCellClick);
@@ -191,6 +258,14 @@
 
         newGameBtn.addEventListener('click', resetGame);
         resetScoresBtn.addEventListener('click', resetScores);
+
+        if (themeToggle) {
+          themeToggle.addEventListener('click', toggleTheme);
+        }
+
+        // Apply theme early based on stored preference or system
+        applyTheme(detectPreferredTheme());
+
         updateStatus(`Player ${playerName(currentPlayer)}'s turn`);
         render();
       }

--- a/tic-tac-toe.html
+++ b/tic-tac-toe.html
@@ -4,24 +4,57 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Tic Tac Toe</title>
+
+  <!-- Apply stored or system theme as early as possible to avoid flash -->
+  <script>
+    (function () {
+      try {
+        var k = 'ttt_theme';
+        var s = localStorage.getItem(k);
+        if (s === 'light' || s === 'dark') {
+          document.documentElement.setAttribute('data-theme', s);
+        } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
+          document.documentElement.setAttribute('data-theme', 'light');
+        }
+      } catch (e) { /* ignore */ }
+    })();
+  </script>
+
   <style>
     :root {
       --bg: #0f1724;
+      --bg-end: #071021; /* used for gradient end stop */
+
       --x: #e11d48;
       --o: #06b6d4;
       --muted: #94a3b8;
       --text: #e6eef8;
       color-scheme: dark;
+
+      /* Surface variables for overlays/borders so themes can override consistently */
+      --surface-bg: rgba(255,255,255,0.02);
+      --surface-border: rgba(255,255,255,0.04);
+      --surface-overlay: rgba(255,255,255,0.01);
+      --surface-overlay-strong: rgba(255,255,255,0.02);
+      --btn-border: rgba(255,255,255,0.06);
     }
 
     /* Light theme overrides applied when document.documentElement has data-theme="light" */
     :root[data-theme="light"] {
       --bg: #f8fafc; /* slate-50 */
+      --bg-end: #f1f5f9; /* light gradient end */
+
       --x: #dc2626; /* red-600 */
       --o: #0ea5a4; /* teal-ish */
       --muted: #475569; /* slate-600 */
       --text: #0f1724; /* slate-900 */
       color-scheme: light;
+
+      --surface-bg: rgba(2,6,23,0.03);
+      --surface-border: rgba(2,6,23,0.04);
+      --surface-overlay: rgba(2,6,23,0.015);
+      --surface-overlay-strong: rgba(2,6,23,0.03);
+      --btn-border: rgba(2,6,23,0.06);
     }
 
     * {
@@ -32,7 +65,7 @@
     body {
       margin: 0;
       font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-      background: linear-gradient(180deg, var(--bg), #071021 120%);
+      background: linear-gradient(180deg, var(--bg), var(--bg-end) 120%);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -43,19 +76,13 @@
     .ttt__container {
       width: 100%;
       max-width: 720px;
-      background: rgba(255,255,255,0.02);
+      background: var(--surface-bg);
       border-radius: 12px;
       padding: 20px 20px 28px;
       box-shadow: 0 6px 30px rgba(2,6,23,0.6);
       position: relative;
       overflow: visible;
-    }
-
-    /* Adjust container background/borders for light theme */
-    :root[data-theme="light"] .ttt__container {
-      background: rgba(15,23,36,0.03);
-      box-shadow: 0 6px 18px rgba(2,6,23,0.06);
-      border: 1px solid rgba(2,6,23,0.04);
+      border: 1px solid transparent;
     }
 
     header {
@@ -72,6 +99,8 @@
     .ttt__status-msg { font-weight: 600; }
     .ttt__status-sub { font-size: 13px; color: var(--muted); }
 
+    .ttt__header-actions { display:flex; align-items:center; gap:12px; }
+
     .ttt__board {
       display: grid;
       grid-template-columns: repeat(3, 1fr);
@@ -83,8 +112,8 @@
       aspect-ratio: 1/1;
       padding: 0;
       border-radius: 10px;
-      border: 2px solid rgba(255,255,255,0.04);
-      background: linear-gradient(180deg, rgba(255,255,255,0.01), transparent);
+      border: 2px solid var(--surface-border);
+      background: linear-gradient(180deg, var(--surface-overlay), transparent);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -94,12 +123,6 @@
       color: var(--muted);
       cursor: pointer;
       user-select: none;
-    }
-
-    /* Lighter borders in light theme */
-    :root[data-theme="light"] .ttt__cell {
-      border-color: rgba(2,6,23,0.06);
-      background: linear-gradient(180deg, rgba(2,6,23,0.015), transparent);
     }
 
     .ttt__cell:focus { outline: 3px solid rgba(124,58,237,0.18); }
@@ -116,17 +139,12 @@
 
     .ttt__btn {
       background: transparent;
-      border: 1px solid rgba(255,255,255,0.06);
+      border: 1px solid var(--btn-border);
       color: inherit;
       padding: 8px 12px;
       border-radius: 8px;
       cursor: pointer;
       transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
-    }
-
-    /* Button borders for light theme */
-    :root[data-theme="light"] .ttt__btn {
-      border-color: rgba(2,6,23,0.06);
     }
 
     .ttt__btn--primary {
@@ -136,7 +154,7 @@
     }
 
     .ttt__score { display: flex; gap: 12px; align-items: center; color: var(--muted); font-size: 14px; }
-    .ttt__score-item { display: inline-flex; gap: 6px; align-items: center; background: rgba(255,255,255,0.02); padding: 6px 8px; border-radius: 8px; }
+    .ttt__score-item { display: inline-flex; gap: 6px; align-items: center; background: var(--surface-overlay-strong); padding: 6px 8px; border-radius: 8px; }
 
     @media (max-width: 420px) {
       :root { --mark-vw-factor: 18vw; }
@@ -149,7 +167,7 @@
   <main class="ttt__container">
     <header>
       <h1>Tic Tac Toe</h1>
-      <div style="display:flex;align-items:center;gap:12px;">
+      <div class="ttt__header-actions">
         <button id="themeToggle" class="ttt__btn" aria-pressed="false" aria-label="Toggle theme">🌙</button>
         <div class="ttt__status">
           <div id="statusMsg" class="ttt__status-msg" aria-live="polite">Waiting...</div>
@@ -263,7 +281,7 @@
           themeToggle.addEventListener('click', toggleTheme);
         }
 
-        // Apply theme early based on stored preference or system
+        // Apply theme early based on stored preference or system (also set earlier in head to avoid flash)
         applyTheme(detectPreferredTheme());
 
         updateStatus(`Player ${playerName(currentPlayer)}'s turn`);


### PR DESCRIPTION
This PR adds a dark/light theme toggle to the single-file Tic Tac Toe web app (tic-tac-toe.html).

Summary of changes:
- Adds a theme toggle button (id="themeToggle") in the header with accessible aria attributes and emoji state.
- Implements CSS variable-based light theme overrides using :root[data-theme="light"] and introduces surface-related variables so visuals adapt correctly in both themes.
- Persists user preference to localStorage under key 'ttt_theme' and respects stored preference before falling back to system preference.
- Adds a small early inline script to set the theme before styles render to avoid a flash of the wrong theme.
- Moves header inline styles into a CSS class and adjusts component styling to ensure adequate contrast across themes.

Notes:
- The application is a browser-only Tic Tac Toe app contained in a single HTML file (tic-tac-toe.html). No backend or additional files were added.
- Resolves issue #46: Dark and light mode toggle.
